### PR TITLE
[HOTT-426] Make logging consistent between our applications

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,8 +25,8 @@ gem "foreman"
 gem "canonical-rails"
 
 # Logging
-gem 'lograge'
-gem 'logstash-event'
+gem "lograge"
+gem "logstash-event"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,6 @@ ruby File.read(".ruby-version").chomp
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem "rails", "~> 6.1.1"
 
-# Use postgresql as the database for Active Record
-gem "pg", ">= 0.18", "< 2.0"
-
 # Use Puma as the app server
 gem "puma", "~> 5.2"
 
@@ -26,6 +23,10 @@ gem "foreman"
 
 # Canonical meta tag
 gem "canonical-rails"
+
+# Logging
+gem 'lograge'
+gem 'logstash-event'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,12 @@ GEM
     listen (3.4.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    lograge (0.11.2)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
+    logstash-event (1.2.02)
     loofah (2.9.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -117,7 +123,6 @@ GEM
     parallel (1.19.2)
     parser (2.7.2.0)
       ast (~> 2.4.1)
-    pg (1.2.3)
     pry (0.13.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -165,6 +170,8 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (2.0.3)
+    request_store (1.5.0)
+      rack (>= 1.4)
     rexml (3.2.4)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
@@ -272,7 +279,8 @@ DEPENDENCIES
   dotenv-rails
   foreman
   listen (>= 3.0.5, < 3.5)
-  pg (>= 0.18, < 2.0)
+  lograge
+  logstash-event
   pry-byebug
   puma (~> 5.2)
   rails (~> 6.1.1)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,4 +51,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.logger = ActiveSupport::Logger.new($stdout)
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,11 +72,9 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new($stdout)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  end
+  config.logger = ActiveSupport::Logger.new($stdout)
+  config.lograge.enabled = true
+  config.lograge.formatter = Lograge::Formatters::Logstash.new
 
   # Do not dump schema after migrations.
   # config.active_record.dump_schema_after_migration = false


### PR DESCRIPTION
### Context

https://transformuk.atlassian.net/browse/HOTT-426

We want to make sure that logging is consistent between our applications.

There will be follow on work to enable filtering on specific json fields in new relic but this formatter change will be added later and discussed separately.

### Changes proposed in this pull request

- Use lograge to subscribe to controller actions and report them in syslog format in one line

### Guidance to review

See other configurations that are currently live to see that this is the same
