### PR TITLE
Add logic for going back to service origin

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+TRADE_TARIFF_FRONTEND_ORIGIN=development

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -1,0 +1,31 @@
+module ServiceHelper
+  TRADE_TARIFF_DOMAINS = {
+    development: 'https://dev.trade-tariff.service.gov.uk',
+    staging: 'https://staging.trade-tariff.service.gov.uk',
+    production: 'https://www.trade-tariff.service.gov.uk',
+  }.freeze
+
+  def trade_tariff_url
+    full_path_for('/sections')
+  end
+
+  def a_to_z_url
+    full_path_for('/a-z-index/a')
+  end
+
+  def tools_url
+    full_path_for('/tools')
+  end
+
+  private
+
+  def full_path_for(relative_path)
+    return '#' if trade_tariff_frontend_origin.blank?
+
+    "#{TRADE_TARIFF_DOMAINS[trade_tariff_frontend_origin.to_sym]}#{relative_path}"
+  end
+
+  def trade_tariff_frontend_origin
+    @trade_tariff_frontend_origin ||= Rails.configuration.trade_tariff_frontend_origin
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,23 +40,7 @@
             </span>
           <% end %>
         </div>
-        <div class="govuk-header__content">
-          <%= link_to "Trade Tariff Duty Calculator", "/", class: "govuk-header__link govuk-header__link--service-name" %>
-          <button type="button" role="button" data-module="govuk-button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
-          <nav>
-            <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
-              <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
-                <%= link_to "Navigation item 1", "#", class: "govuk-header__link" %>
-              </li>
-              <li class="govuk-header__navigation-item">
-                <%= link_to "Navigation item 2", "#", class: "govuk-header__link" %>
-              </li>
-              <li class="govuk-header__navigation-item">
-                <%= link_to "Navigation item 3", "#", class: "govuk-header__link" %>
-              </li>
-            </ul>
-          </nav>
-        </div>
+        <%= render 'navbar/main' %>
       </div>
     </header>
 

--- a/app/views/navbar/_main.html.erb
+++ b/app/views/navbar/_main.html.erb
@@ -1,0 +1,22 @@
+<div class="govuk-header__content">
+  <a href="#" class="govuk-header__link govuk-header__link--service-name" id="proposition-name">
+    Trade Tariff Duty Calculator
+  </a>
+  <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="proposition-links" aria-label="Show or hide Top Level Navigation">Menu</button>
+  <nav id="proposition-menu"  aria-label="Top Level Navigation">
+    <ul id="proposition-links" class="govuk-header__navigation ">
+      <li class="govuk-header__navigation-item">
+        <%= link_to 'Search or browse the Tariff', trade_tariff_url, class: "govuk-header__link" %>
+      </li>
+      <li class="govuk-header__navigation-item">
+        <%= link_to "A-Z", a_to_z_url, class: "govuk-header__link" %>
+      </li>
+      <li class="govuk-header__navigation-item">
+        <%= link_to "Tools", tools_url, class: "govuk-header__link" %>
+      </li>
+      <li class="govuk-header__navigation-item">
+        <%= link_to "Latest News", '#', class: "govuk-header__link" %>
+      </li>
+    </ul>
+  </nav>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,7 @@ module TradeTariffDutyCalculator
     config.exceptions_app = routes
 
     config.middleware.use Rack::Deflater
+
+    config.trade_tariff_frontend_origin = ENV['TRADE_TARIFF_FRONTEND_ORIGIN']
   end
 end

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+RSpec.describe ServiceHelper do
+  before do
+    allow(Rails.configuration).to receive(:trade_tariff_frontend_origin).and_return(environment)
+  end
+
+  describe 'trade_tariff_url' do
+    context 'when TRADE_TARIFF_FRONTEND_ORIGIN is set to development' do
+      let(:environment) { 'development' }
+
+      it 'returns the dev trade tariff url' do
+        expect(helper.trade_tariff_url).to eq(
+          'https://dev.trade-tariff.service.gov.uk/sections',
+        )
+      end
+    end
+
+    context 'when TRADE_TARIFF_FRONTEND_ORIGIN is set to staging' do
+      let(:environment) { 'staging' }
+
+      it 'returns the staging trade tariff url' do
+        expect(helper.trade_tariff_url).to eq(
+          'https://staging.trade-tariff.service.gov.uk/sections',
+        )
+      end
+    end
+
+    context 'when TRADE_TARIFF_FRONTEND_ORIGIN is set to production' do
+      let(:environment) { 'production' }
+
+      it 'returns the production trade tariff url' do
+        expect(helper.trade_tariff_url).to eq(
+          'https://www.trade-tariff.service.gov.uk/sections',
+        )
+      end
+    end
+  end
+
+  describe 'a_to_z_url' do
+    context 'when TRADE_TARIFF_FRONTEND_ORIGIN is set to development' do
+      let(:environment) { 'development' }
+
+      it 'returns the dev trade tariff a to z url' do
+        expect(helper.a_to_z_url).to eq(
+          'https://dev.trade-tariff.service.gov.uk/a-z-index/a',
+        )
+      end
+    end
+
+    context 'when TRADE_TARIFF_FRONTEND_ORIGIN is set to staging' do
+      let(:environment) { 'staging' }
+
+      it 'returns the staging trade tariff a to z url' do
+        expect(helper.a_to_z_url).to eq(
+          'https://staging.trade-tariff.service.gov.uk/a-z-index/a',
+        )
+      end
+    end
+
+    context 'when TRADE_TARIFF_FRONTEND_ORIGIN is set to production' do
+      let(:environment) { 'production' }
+
+      it 'returns the production trade tariff a to z url' do
+        expect(helper.a_to_z_url).to eq(
+          'https://www.trade-tariff.service.gov.uk/a-z-index/a',
+        )
+      end
+    end
+  end
+
+  describe 'tools_url' do
+    context 'when TRADE_TARIFF_FRONTEND_ORIGIN is set to development' do
+      let(:environment) { 'development' }
+
+      it 'returns the dev trade tariff tools url' do
+        expect(helper.tools_url).to eq(
+          'https://dev.trade-tariff.service.gov.uk/tools',
+        )
+      end
+    end
+
+    context 'when TRADE_TARIFF_FRONTEND_ORIGIN is set to staging' do
+      let(:environment) { 'staging' }
+
+      it 'returns the staging trade tariff tools url' do
+        expect(helper.tools_url).to eq(
+          'https://staging.trade-tariff.service.gov.uk/tools',
+        )
+      end
+    end
+
+    context 'when TRADE_TARIFF_FRONTEND_ORIGIN is set to production' do
+      let(:environment) { 'production' }
+
+      it 'returns the production trade tariff tools url' do
+        expect(helper.tools_url).to eq(
+          'https://www.trade-tariff.service.gov.uk/tools',
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

HOTT-429

### What?

Add logic for going back to service origin for the navbar

### Why?

The links in our current navbar have to navigate back
to the Trade Tariff service, using the right env.