### PR TITLE
Move JS custom code outside application.js

### DIFF
--- a/app/views/wizard/steps/country_of_origin/show.html.erb
+++ b/app/views/wizard/steps/country_of_origin/show.html.erb
@@ -37,3 +37,5 @@
     </div>
   </div>
 </main>
+
+<%= javascript_pack_tag 'country-of-origin' %>

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -5,13 +5,6 @@ import Rails from 'rails-ujs';
 import Turbolinks from 'turbolinks';
 import { initAll } from 'govuk-frontend';
 
-import accessibleAutocomplete from 'accessible-autocomplete'
-
-accessibleAutocomplete.enhanceSelectElement({
-  defaultValue: '',
-  selectElement: document.querySelector('[id^="wizard-steps-country-of-origin-geographical-area-id-field"]')
-})
-
 Rails.start();
 Turbolinks.start();
 initAll();

--- a/app/webpacker/packs/country-of-origin.js
+++ b/app/webpacker/packs/country-of-origin.js
@@ -1,0 +1,6 @@
+import accessibleAutocomplete from 'accessible-autocomplete'
+
+accessibleAutocomplete.enhanceSelectElement({
+  defaultValue: '',
+  selectElement: document.querySelector('[id^="wizard-steps-country-of-origin-geographical-area-id-field"]')
+})


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

Move JS custom code outside application.js

### Why?

We want to load the autocomplete js on demand,
on the page we actually need it.

Also removes JS console errors.