### PR TITLE
Adds route prefixes for both UK and XI regions

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -5,6 +5,8 @@ applications:
     - https://github.com/cloudfoundry/ruby-buildpack.git
   stack: cflinuxfs3
   routes:
+  - route: dev.trade-tariff.service.gov.uk/uk/duty-calculator
+  - route: dev.trade-tariff.service.gov.uk/xi/duty-calculator
   - route: tariff-duty-calculator-dev.london.cloudapps.digital
   processes:
   - type: web


### PR DESCRIPTION
### Jira link

HOTT-437

### What?

I have added/removed/altered:

- [ ] Mounts the application on path prefixes for /xi and /uk

### Why?

I am doing this because:
- We want to map the same application onto two different routes. One for each region.
- 

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Makes changes to our complex routing setup that may affect apis to proxying to backend
