### PR TITLE
Adding UserSession wrapper around the session

### DIFF
--- a/app/controllers/wizard/steps/base_controller.rb
+++ b/app/controllers/wizard/steps/base_controller.rb
@@ -12,6 +12,10 @@ module Wizard
         )
       end
 
+      def user_session
+        @user_session ||= UserSession.new(session)
+      end
+
       protected
 
       def commodity_code

--- a/app/controllers/wizard/steps/country_of_origin_controller.rb
+++ b/app/controllers/wizard/steps/country_of_origin_controller.rb
@@ -2,11 +2,11 @@ module Wizard
   module Steps
     class CountryOfOriginController < BaseController
       def show
-        @country = Wizard::Steps::CountryOfOrigin.new(session)
+        @country = Wizard::Steps::CountryOfOrigin.new(user_session)
       end
 
       def create
-        @country = Wizard::Steps::CountryOfOrigin.new(session, permitted_params)
+        @country = Wizard::Steps::CountryOfOrigin.new(user_session, permitted_params)
 
         if @country.valid?
           @country.save

--- a/app/controllers/wizard/steps/import_dates_controller.rb
+++ b/app/controllers/wizard/steps/import_dates_controller.rb
@@ -2,11 +2,11 @@ module Wizard
   module Steps
     class ImportDatesController < BaseController
       def show
-        @import_date = Wizard::Steps::ImportDate.new(session)
+        @import_date = Wizard::Steps::ImportDate.new(user_session)
       end
 
       def create
-        @import_date = Wizard::Steps::ImportDate.new(session, permitted_params)
+        @import_date = Wizard::Steps::ImportDate.new(user_session, permitted_params)
 
         if @import_date.valid?
           @import_date.save

--- a/app/controllers/wizard/steps/import_destinations_controller.rb
+++ b/app/controllers/wizard/steps/import_destinations_controller.rb
@@ -2,11 +2,11 @@ module Wizard
   module Steps
     class ImportDestinationsController < BaseController
       def show
-        @import_destination = Wizard::Steps::ImportDestination.new(session)
+        @import_destination = Wizard::Steps::ImportDestination.new(user_session)
       end
 
       def create
-        @import_destination = Wizard::Steps::ImportDestination.new(session, permitted_params)
+        @import_destination = Wizard::Steps::ImportDestination.new(user_session, permitted_params)
 
         if @import_destination.valid?
           @import_destination.save

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -1,0 +1,41 @@
+class UserSession
+  attr_reader :session
+
+  def initialize(session)
+    @session = session
+  end
+
+  def remove_keys_after(key)
+    keys_to_remove = session.keys.map(&:to_i).uniq.select { |k| k > key }
+
+    return if keys_to_remove.empty?
+
+    session.delete(*keys_to_remove)
+  end
+
+  def import_date
+    return unless session.key?(Wizard::Steps::ImportDate::STEP_ID)
+
+    Date.parse(session[Wizard::Steps::ImportDate::STEP_ID])
+  end
+
+  def import_date=(value)
+    session[Wizard::Steps::ImportDate::STEP_ID] = value
+  end
+
+  def import_destination
+    session[Wizard::Steps::ImportDestination::STEP_ID]
+  end
+
+  def import_destination=(value)
+    session[Wizard::Steps::ImportDestination::STEP_ID] = value
+  end
+
+  def geographical_area_id
+    session[Wizard::Steps::CountryOfOrigin::STEP_ID]
+  end
+
+  def geographical_area_id=(value)
+    session[Wizard::Steps::CountryOfOrigin::STEP_ID] = value
+  end
+end

--- a/app/models/wizard/steps/base.rb
+++ b/app/models/wizard/steps/base.rb
@@ -4,12 +4,12 @@ module Wizard
       include ActiveModel::Model
       include ActiveModel::Attributes
 
-      attr_reader :session
+      attr_reader :user_session
 
-      def initialize(session, attributes = {})
-        @session = session
+      def initialize(user_session, attributes = {})
+        @user_session = user_session
 
-        clean_session if attributes.empty?
+        clean_user_session if attributes.empty?
 
         super(attributes)
       end
@@ -20,14 +20,8 @@ module Wizard
 
       private
 
-      def clean_session
-        return if keys_to_remove.empty?
-
-        session.delete(*keys_to_remove)
-      end
-
-      def keys_to_remove
-        session.keys.map(&:to_i).uniq.select { |key| key > self.class::STEP_ID.to_i }
+      def clean_user_session
+        @user_session.remove_keys_after(self.class::STEP_ID.to_i)
       end
     end
   end

--- a/app/models/wizard/steps/country_of_origin.rb
+++ b/app/models/wizard/steps/country_of_origin.rb
@@ -8,11 +8,11 @@ module Wizard
       validates :geographical_area_id, presence: true
 
       def geographical_area_id
-        super || session[STEP_ID]
+        super || user_session.geographical_area_id
       end
 
       def save
-        session[STEP_ID] = geographical_area_id
+        user_session.geographical_area_id = geographical_area_id
       end
 
       def self.options_for(service)

--- a/app/models/wizard/steps/import_date.rb
+++ b/app/models/wizard/steps/import_date.rb
@@ -13,18 +13,18 @@ module Wizard
 
       validate :import_date_in_future
 
-      def initialize(session, attributes = {})
+      def initialize(user_session, attributes = {})
         check_attributes_validity(attributes)
 
         super
       end
 
       def import_date
-        super || date_from_session
+        super || user_session.import_date
       end
 
       def save
-        session[STEP_ID] = input_date.strftime('%Y-%m-%d')
+        user_session.import_date = input_date.strftime('%Y-%m-%d')
       end
 
     private
@@ -33,12 +33,6 @@ module Wizard
         return if input_date.present? && input_date >= Time.zone.today
 
         errors.add(:import_date, :invalid_date)
-      end
-
-      def date_from_session
-        return unless session.key?(STEP_ID)
-
-        Date.parse(session[STEP_ID])
       end
 
       def valid_date?(attributes)

--- a/app/models/wizard/steps/import_destination.rb
+++ b/app/models/wizard/steps/import_destination.rb
@@ -13,11 +13,11 @@ module Wizard
       validates :import_destination, presence: true
 
       def import_destination
-        super || session[STEP_ID]
+        super || user_session.import_destination
       end
 
       def save
-        session[STEP_ID] = import_destination
+        user_session.import_destination = import_destination
       end
     end
   end

--- a/app/models/wizard/steps/import_destination.rb
+++ b/app/models/wizard/steps/import_destination.rb
@@ -2,8 +2,8 @@ module Wizard
   module Steps
     class ImportDestination < Base
       OPTIONS = [
-        OpenStruct.new(id: 1, name: 'England, Scotland or Wales (GB)'),
-        OpenStruct.new(id: 2, name: 'Northern Ireland'),
+        OpenStruct.new(id: 'gb', name: 'England, Scotland or Wales (GB)'),
+        OpenStruct.new(id: 'ni', name: 'Northern Ireland'),
       ].freeze
 
       STEP_ID = '2'.freeze

--- a/spec/features/country_of_origin_page_spec.rb
+++ b/spec/features/country_of_origin_page_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Country of Origin Page', type: :feature do
 
     click_on('Continue')
 
-    choose(option: '2')
+    choose(option: 'ni')
 
     click_on('Continue')
   end

--- a/spec/features/import_destination_page_spec.rb
+++ b/spec/features/import_destination_page_spec.rb
@@ -21,15 +21,15 @@ RSpec.describe 'Import Destination Page', type: :feature do
   end
 
   it 'does store a invalid import date on the session' do
-    choose(option: '2')
+    choose(option: 'ni')
 
     click_on('Continue')
 
-    expect(Capybara.current_session.driver.request.session[Wizard::Steps::ImportDestination::STEP_ID]).to eq('2')
+    expect(Capybara.current_session.driver.request.session[Wizard::Steps::ImportDestination::STEP_ID]).to eq('ni')
   end
 
   it 'loses its session key when going back to the previous question' do
-    choose(option: '2')
+    choose(option: 'ni')
 
     click_on('Continue')
 

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -17,9 +17,7 @@ RSpec.describe Wizard::Steps::UserSession do
         }
       end
 
-      let(:expected_date) do
-        Date.parse('2025-01-01')
-      end
+      let(:expected_date) { Date.parse('2025-01-01') }
 
       it 'returns the date from the session' do
         expect(user_session.import_date).to eq(expected_date)
@@ -28,9 +26,7 @@ RSpec.describe Wizard::Steps::UserSession do
   end
 
   describe '#import_date=' do
-    let(:expected_date) do
-      '2025-01-01'
-    end
+    let(:expected_date) { '2025-01-01' }
 
     it 'sets the key on the session' do
       user_session.import_date = '2025-01-01'

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+RSpec.describe Wizard::Steps::UserSession do
+  subject(:user_session) { described_class.new(session) }
+
+  let(:session) { {} }
+
+  describe '#import_date' do
+    it 'returns nil if the key is not on the session' do
+      expect(user_session.import_date).to be nil
+    end
+
+    context 'when the key is present on the session' do
+      let(:session) do
+        {
+          Wizard::Steps::ImportDate::STEP_ID => '2025-01-01',
+        }
+      end
+
+      let(:expected_date) do
+        Date.parse('2025-01-01')
+      end
+
+      it 'returns the date from the session' do
+        expect(user_session.import_date).to eq(expected_date)
+      end
+    end
+  end
+
+  describe '#import_date=' do
+    let(:expected_date) do
+      '2025-01-01'
+    end
+
+    it 'sets the key on the session' do
+      user_session.import_date = '2025-01-01'
+
+      expect(session[Wizard::Steps::ImportDate::STEP_ID]).to eq(expected_date)
+    end
+  end
+
+  describe '#import_destination' do
+    it 'returns nil if the key is not on the session' do
+      expect(user_session.import_destination).to be nil
+    end
+
+    context 'when the key is present on the session' do
+      let(:session) do
+        {
+          Wizard::Steps::ImportDestination::STEP_ID => 'ni',
+        }
+      end
+
+      let(:expected_country) { 'ni' }
+
+      it 'returns the date from the session' do
+        expect(user_session.import_destination).to eq(expected_country)
+      end
+    end
+  end
+
+  describe '#import_destination=' do
+    let(:expected_country) { 'ni' }
+
+    it 'sets the key on the session' do
+      user_session.import_destination = 'ni'
+
+      expect(session[Wizard::Steps::ImportDestination::STEP_ID]).to eq(expected_country)
+    end
+  end
+
+  describe '#geographical_area_id' do
+    it 'returns nil if the key is not on the session' do
+      expect(user_session.geographical_area_id).to be nil
+    end
+
+    context 'when the key is present on the session' do
+      let(:session) do
+        {
+          Wizard::Steps::CountryOfOrigin::STEP_ID => '1234',
+        }
+      end
+
+      let(:expected_country) { '1234' }
+
+      it 'returns the date from the session' do
+        expect(user_session.geographical_area_id).to eq(expected_country)
+      end
+    end
+  end
+
+  describe '#geographical_area_id=' do
+    let(:expected_country) { '1234' }
+
+    it 'sets the key on the session' do
+      user_session.geographical_area_id = '1234'
+
+      expect(session[Wizard::Steps::CountryOfOrigin::STEP_ID]).to eq(expected_country)
+    end
+  end
+end

--- a/spec/models/wizard/steps/country_of_origin_spec.rb
+++ b/spec/models/wizard/steps/country_of_origin_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Wizard::Steps::CountryOfOrigin do
-  subject(:country) { described_class.new(session, attributes) }
+  subject(:country) { described_class.new(user_session, attributes) }
 
   let(:session) { {} }
+  let(:user_session) { UserSession.new(session) }
 
   let(:attributes) do
     ActionController::Parameters.new(
@@ -44,12 +45,6 @@ RSpec.describe Wizard::Steps::CountryOfOrigin do
   end
 
   describe '#save' do
-    let(:expected_session) do
-      {
-        Wizard::Steps::CountryOfOrigin::STEP_ID => '2',
-      }
-    end
-
     let(:attributes) do
       ActionController::Parameters.new(
         'geographical_area_id' => '2',
@@ -59,7 +54,7 @@ RSpec.describe Wizard::Steps::CountryOfOrigin do
     it 'saves the geographical_area_id to the session' do
       country.save
 
-      expect(country.session).to eq(expected_session)
+      expect(user_session.geographical_area_id).to eq '2'
     end
   end
 end

--- a/spec/models/wizard/steps/import_date_spec.rb
+++ b/spec/models/wizard/steps/import_date_spec.rb
@@ -128,12 +128,12 @@ RSpec.describe Wizard::Steps::ImportDate do
   end
 
   describe '#save' do
-    let(:expected_date) { "#{1.year.from_now.year}-12-12" }
+    let(:expected_date) { Date.parse("#{1.year.from_now.year}-12-12") }
 
     it 'saves the import_date to the session' do
       import_date.save
 
-      expect(user_session.import_date).to eq(Date.parse(expected_date))
+      expect(user_session.import_date).to eq(expected_date)
     end
   end
 end

--- a/spec/models/wizard/steps/import_date_spec.rb
+++ b/spec/models/wizard/steps/import_date_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Wizard::Steps::ImportDate do
-  subject(:import_date) { described_class.new(session, attributes) }
+  subject(:import_date) { described_class.new(user_session, attributes) }
 
   let(:session) { {} }
+  let(:user_session) { UserSession.new(session) }
   let(:attributes) do
     ActionController::Parameters.new(
       'import_date(3i)' => '12',
@@ -127,16 +128,12 @@ RSpec.describe Wizard::Steps::ImportDate do
   end
 
   describe '#save' do
-    let(:expected_session) do
-      {
-        Wizard::Steps::ImportDate::STEP_ID => "#{1.year.from_now.year}-12-12",
-      }
-    end
+    let(:expected_date) { "#{1.year.from_now.year}-12-12" }
 
     it 'saves the import_date to the session' do
       import_date.save
 
-      expect(import_date.session).to eq(expected_session)
+      expect(user_session.import_date).to eq(Date.parse(expected_date))
     end
   end
 end

--- a/spec/models/wizard/steps/import_destination_spec.rb
+++ b/spec/models/wizard/steps/import_destination_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Wizard::Steps::ImportDestination do
-  subject(:import_destination) { described_class.new(session, attributes) }
+  subject(:country) { described_class.new(user_session, attributes) }
 
   let(:session) { {} }
+  let(:user_session) { UserSession.new(session) }
   let(:attributes) do
     ActionController::Parameters.new(
       'import_destination' => '',
@@ -13,52 +14,46 @@ RSpec.describe Wizard::Steps::ImportDestination do
   describe '#validations' do
     context 'when import destination is blank' do
       it 'is not a valid object' do
-        expect(import_destination.valid?).to be false
+        expect(country.valid?).to be false
       end
 
       it 'adds the correct validation error message' do
-        import_destination.valid?
+        country.valid?
 
-        expect(import_destination.errors.messages[:import_destination]).to eq(['Select a destination'])
+        expect(country.errors.messages[:import_destination]).to eq(['Select a destination'])
       end
     end
 
     context 'when import destination is present' do
       let(:attributes) do
         ActionController::Parameters.new(
-          'import_destination' => '1',
+          'import_destination' => 'gb',
         ).permit!
       end
 
       it 'is a valid object' do
-        expect(import_destination.valid?).to be true
+        expect(country.valid?).to be true
       end
 
       it 'has no validation errors' do
-        import_destination.valid?
+        country.valid?
 
-        expect(import_destination.errors.messages[:import_destination]).to be_empty
+        expect(country.errors.messages[:import_destination]).to be_empty
       end
     end
   end
 
   describe '#save' do
-    let(:expected_session) do
-      {
-        Wizard::Steps::ImportDestination::STEP_ID => '2',
-      }
-    end
-
     let(:attributes) do
       ActionController::Parameters.new(
-        'import_destination' => '2',
+        'import_destination' => 'ni',
       ).permit!
     end
 
     it 'saves the import_date to the session' do
-      import_destination.save
+      country.save
 
-      expect(import_destination.session).to eq(expected_session)
+      expect(user_session.import_destination).to eq('ni')
     end
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-452

### What?

I have added/removed/altered:

- [x] Use more readable ids for GB and NI
- [x] Add UserSession wrapper around the session

### Why?

- Because we need to do some intensive logic around the country of import, it's easier to store the country codes on the session rather than incremental ids. We could not use geographical area ids because we don't have the entries for these 2 options.
- The session should not be accessed directly within the models.