### PR TITLE
This PR adds the following:

### DIFF
--- a/app/controllers/wizard/steps/country_of_origin_controller.rb
+++ b/app/controllers/wizard/steps/country_of_origin_controller.rb
@@ -2,14 +2,19 @@ module Wizard
   module Steps
     class CountryOfOriginController < BaseController
       def show
-        @country = Wizard::Steps::CountryOfOrigin.new(user_session)
+        @step = Wizard::Steps::CountryOfOrigin.new(user_session)
       end
 
       def create
-        @country = Wizard::Steps::CountryOfOrigin.new(user_session, permitted_params)
+        @step = Wizard::Steps::CountryOfOrigin.new(user_session, permitted_params)
 
-        if @country.valid?
-          @country.save
+        if @step.valid?
+          @step.save
+
+          redirect_to @step.next_step_path(
+            service_choice: params[:service_choice],
+            commodity_code: params[:commodity_code],
+          )
         else
           render 'show'
         end

--- a/app/controllers/wizard/steps/duties_controller.rb
+++ b/app/controllers/wizard/steps/duties_controller.rb
@@ -1,0 +1,9 @@
+module Wizard
+  module Steps
+    class DutiesController < BaseController
+      def show
+        @duty = DutyCalculator.new(user_session).result
+      end
+    end
+  end
+end

--- a/app/controllers/wizard/steps/import_dates_controller.rb
+++ b/app/controllers/wizard/steps/import_dates_controller.rb
@@ -2,14 +2,14 @@ module Wizard
   module Steps
     class ImportDatesController < BaseController
       def show
-        @import_date = Wizard::Steps::ImportDate.new(user_session)
+        @step = Wizard::Steps::ImportDate.new(user_session)
       end
 
       def create
-        @import_date = Wizard::Steps::ImportDate.new(user_session, permitted_params)
+        @step = Wizard::Steps::ImportDate.new(user_session, permitted_params)
 
-        if @import_date.valid?
-          @import_date.save
+        if @step.valid?
+          @step.save
 
           redirect_to import_destination_path
         else

--- a/app/controllers/wizard/steps/import_destinations_controller.rb
+++ b/app/controllers/wizard/steps/import_destinations_controller.rb
@@ -2,14 +2,14 @@ module Wizard
   module Steps
     class ImportDestinationsController < BaseController
       def show
-        @import_destination = Wizard::Steps::ImportDestination.new(user_session)
+        @step = Wizard::Steps::ImportDestination.new(user_session)
       end
 
       def create
-        @import_destination = Wizard::Steps::ImportDestination.new(user_session, permitted_params)
+        @step = Wizard::Steps::ImportDestination.new(user_session, permitted_params)
 
-        if @import_destination.valid?
-          @import_destination.save
+        if @step.valid?
+          @step.save
 
           redirect_to country_of_origin_path
         else

--- a/app/models/duty_calculator.rb
+++ b/app/models/duty_calculator.rb
@@ -1,0 +1,11 @@
+class DutyCalculator
+  attr_reader :user_session
+
+  def initialize(user_session)
+    @user_session = user_session
+  end
+
+  def result
+    0 if user_session.ni_to_gb_route?
+  end
+end

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -38,4 +38,8 @@ class UserSession
   def geographical_area_id=(value)
     session[Wizard::Steps::CountryOfOrigin::STEP_ID] = value
   end
+
+  def ni_to_gb_route?
+    import_destination == 'GB' && geographical_area_id == 'XI'
+  end
 end

--- a/app/models/wizard/steps/base.rb
+++ b/app/models/wizard/steps/base.rb
@@ -22,7 +22,7 @@ module Wizard
       protected
 
       def next_step_path(*)
-        raise('Must implement this method')
+        raise NotImplementedError
       end
 
       def previous_step_path(*)

--- a/app/models/wizard/steps/base.rb
+++ b/app/models/wizard/steps/base.rb
@@ -3,6 +3,7 @@ module Wizard
     class Base
       include ActiveModel::Model
       include ActiveModel::Attributes
+      include Rails.application.routes.url_helpers
 
       attr_reader :user_session
 
@@ -16,6 +17,16 @@ module Wizard
 
       def persisted?
         false
+      end
+
+      protected
+
+      def next_step_path(*)
+        raise('Must implement this method')
+      end
+
+      def previous_step_path(*)
+        raise('Must implement this method')
       end
 
       private

--- a/app/models/wizard/steps/country_of_origin.rb
+++ b/app/models/wizard/steps/country_of_origin.rb
@@ -18,6 +18,14 @@ module Wizard
       def self.options_for(service)
         Country.list(service.to_sym)
       end
+
+      def next_step_path(service_choice:, commodity_code:)
+        duty_path(service_choice: service_choice, commodity_code: commodity_code) if user_session.ni_to_gb_route?
+      end
+
+      def previous_step_path(service_choice:, commodity_code:)
+        import_destination_path(service_choice: service_choice, commodity_code: commodity_code)
+      end
     end
   end
 end

--- a/app/models/wizard/steps/import_date.rb
+++ b/app/models/wizard/steps/import_date.rb
@@ -27,6 +27,10 @@ module Wizard
         user_session.import_date = input_date.strftime('%Y-%m-%d')
       end
 
+      def next_step_path(service_choice:, commodity_code:)
+        import_destination_path(service_choice: service_choice, commodity_code: commodity_code)
+      end
+
     private
 
       def import_date_in_future

--- a/app/models/wizard/steps/import_destination.rb
+++ b/app/models/wizard/steps/import_destination.rb
@@ -2,8 +2,8 @@ module Wizard
   module Steps
     class ImportDestination < Base
       OPTIONS = [
-        OpenStruct.new(id: 'gb', name: 'England, Scotland or Wales (GB)'),
-        OpenStruct.new(id: 'ni', name: 'Northern Ireland'),
+        OpenStruct.new(id: 'GB', name: 'England, Scotland or Wales (GB)'),
+        OpenStruct.new(id: 'XI', name: 'Northern Ireland'),
       ].freeze
 
       STEP_ID = '2'.freeze
@@ -18,6 +18,14 @@ module Wizard
 
       def save
         user_session.import_destination = import_destination
+      end
+
+      def next_step_path(service_choice:, commodity_code:)
+        country_of_origin_path(service_choice: service_choice, commodity_code: commodity_code)
+      end
+
+      def previous_step_path(service_choice:, commodity_code:)
+        import_date_path(service_choice: service_choice, commodity_code: commodity_code)
       end
     end
   end

--- a/app/views/wizard/steps/country_of_origin/show.html.erb
+++ b/app/views/wizard/steps/country_of_origin/show.html.erb
@@ -1,10 +1,10 @@
-<%= link_to('Back', import_destination_path(service_choice: params[:service_choice], commodity_code: params[:commodity_code]), class: "govuk-back-link") %>
+<%= link_to('Back', @step.previous_step_path(service_choice: params[:service_choice], commodity_code: params[:commodity_code]), class: "govuk-back-link") %>
 
 <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
       <span class="govuk-caption-xl">Calculate import duties</span>
-      <%= form_for @country, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: country_of_origin_path do |f| %>
+      <%= form_for @step, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: country_of_origin_path do |f| %>
         <%= f.govuk_error_summary %>
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
@@ -17,10 +17,7 @@
               The duty you are charged may be dependent on the country of dispatch of the goods being imported.
             </div>
             <%= f.govuk_collection_select :geographical_area_id, Wizard::Steps::CountryOfOrigin.options_for(params[:service_choice]), :id, :name, options: { prompt: true }, label: { text: 'Enter the country of dispatch:' } %>
-            <p class="govuk-!-margin-top-3 govuk-hint">When autocomplete results are available,
-              use up and down arrows to review and
-              enter to select. Touch device users, explore by touch or with swipe gestures.
-            </p>
+            <p class="govuk-!-margin-top-3 govuk-hint">When autocomplete results are available, use up and down arrows to review and enter to select. Touch device users, explore by touch or with swipe gestures.</p>
           </div>
            <%= f.govuk_submit %>
         </fieldset>

--- a/app/views/wizard/steps/duties/_no_duty.html.erb
+++ b/app/views/wizard/steps/duties/_no_duty.html.erb
@@ -1,0 +1,4 @@
+<% if @user_session.ni_to_gb_route? %>
+  <p class="govuk-body govuk-!-margin-top-5">There are no import duties applicable to the movement of goods from Northern Ireland to England, Scotland and Wales.</p>
+  <p class="govuk-body">Find out more about <%= link_to('trading and moving goods in and out of Northern Ireland(opens in a new window).', 'https://www.gov.uk/guidance/trading-and-moving-goods-in-and-out-of-northern-ireland', class: 'govuk-link', target: '_blank') %></p>
+<% end %>

--- a/app/views/wizard/steps/duties/show.html.erb
+++ b/app/views/wizard/steps/duties/show.html.erb
@@ -1,0 +1,17 @@
+<%= link_to('Back', :back, class: "govuk-back-link") %>
+
+<main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters">
+      <span class="govuk-caption-xl">Calculate import duties</span>
+      <% if @duty.zero? %>
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+            <h1 class="govuk-fieldset__heading">There is no import duty to pay</h1>
+          </legend>
+        </fieldset>
+        <%= render 'no_duty' %>
+      <% end %>
+    </div>
+  </div>
+</main>

--- a/app/views/wizard/steps/import_dates/show.html.erb
+++ b/app/views/wizard/steps/import_dates/show.html.erb
@@ -3,7 +3,7 @@
 <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
-      <%= form_for @import_date, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: import_date_path, html: { novalidate: true } do |f| %>
+      <%= form_for @step, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: import_date_path, html: { novalidate: true } do |f| %>
         <%= f.govuk_error_summary %>
         <span class="govuk-caption-xl">Calculate import duties</span>
         <%= f.govuk_date_field :import_date, legend: { text: 'When will the goods be imported?', size: 'xl', tag: 'h1' }, hint: { text: 'As duties and quotas change over time, it may be important to enter the proposed import date. For example, 27  3  2021' } %>

--- a/app/views/wizard/steps/import_destinations/show.html.erb
+++ b/app/views/wizard/steps/import_destinations/show.html.erb
@@ -1,9 +1,9 @@
-<%= link_to('Back', import_date_path(service_choice: params[:service_choice], commodity_code: params[:commodity_code]), class: "govuk-back-link") %>
+<%= link_to('Back', @step.previous_step_path(service_choice: params[:service_choice], commodity_code: params[:commodity_code]), class: "govuk-back-link") %>
 
 <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
-      <%= form_for @import_destination, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: { controller: 'wizard/steps/import_destinations', action: 'create' } do |f| %>
+      <%= form_for @step, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: { controller: 'wizard/steps/import_destinations', action: 'create' } do |f| %>
         <%= f.govuk_error_summary %>
         <span class="govuk-caption-xl">Calculate import duties</span>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
 
     get 'country-of-origin', to: 'wizard/steps/country_of_origin#show'
     post 'country-of-origin', to: 'wizard/steps/country_of_origin#create'
+
+    get 'duty', to: 'wizard/steps/duties#show'
   end
 
   get '404', to: 'errors#not_found', via: :all

--- a/spec/features/country_of_origin_page_spec.rb
+++ b/spec/features/country_of_origin_page_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Country of Origin Page', type: :feature do
   let(:commodity_code) { '1234567890' }
   let(:service_choice) { 'uk' }
+  let(:import_into) { 'GB' }
 
   before do
     visit import_date_path(commodity_code: commodity_code, service_choice: service_choice)
@@ -13,7 +14,7 @@ RSpec.describe 'Country of Origin Page', type: :feature do
 
     click_on('Continue')
 
-    choose(option: 'ni')
+    choose(option: import_into)
 
     click_on('Continue')
   end
@@ -24,7 +25,32 @@ RSpec.describe 'Country of Origin Page', type: :feature do
     expect(Capybara.current_session.driver.request.session.key?(Wizard::Steps::CountryOfOrigin::STEP_ID)).to be false
   end
 
-  xit 'loses its session key when going back to the previous question' do
-    # TODO: add steps for here when the next page is available
+  it 'does store the country of origin date on the session' do
+    select('United Kingdom (Northern Ireland)', from: 'wizard_steps_country_of_origin[geographical_area_id]')
+
+    click_on('Continue')
+
+    expect(Capybara.current_session.driver.request.session[Wizard::Steps::CountryOfOrigin::STEP_ID]).to eq('XI')
+  end
+
+  it 'loses its session key when going back to the previous question' do
+    select('United Kingdom (Northern Ireland)', from: 'wizard_steps_country_of_origin[geographical_area_id]')
+
+    click_on('Continue')
+
+    click_on('Back')
+    click_on('Back')
+
+    expect(Capybara.current_session.driver.request.session.key?(Wizard::Steps::CountryOfOrigin::STEP_ID)).to be false
+  end
+
+  context 'when importing from NI to GB' do
+    it 'redirects to duty path' do
+      select('United Kingdom (Northern Ireland)', from: 'wizard_steps_country_of_origin[geographical_area_id]')
+
+      click_on('Continue')
+
+      expect(page).to have_current_path(duty_path(service_choice: service_choice, commodity_code: commodity_code))
+    end
   end
 end

--- a/spec/features/import_date_page_spec.rb
+++ b/spec/features/import_date_page_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Import Date Page', type: :feature do
     expect(Capybara.current_session.driver.request.session[Wizard::Steps::ImportDate::STEP_ID]).to eq('3000-12-12')
   end
 
-  it 'redirects to import-destination page if the validation is successful' do
+  it 'redirects to import destination page if the validation is successful' do
     visit import_date_path(commodity_code: commodity_code, service_choice: service_choice)
 
     fill_in('wizard_steps_import_date[import_date(3i)]', with: '12')

--- a/spec/features/import_destination_page_spec.rb
+++ b/spec/features/import_destination_page_spec.rb
@@ -21,19 +21,20 @@ RSpec.describe 'Import Destination Page', type: :feature do
   end
 
   it 'does store a invalid import date on the session' do
-    choose(option: 'ni')
+    choose(option: 'XI')
 
     click_on('Continue')
 
-    expect(Capybara.current_session.driver.request.session[Wizard::Steps::ImportDestination::STEP_ID]).to eq('ni')
+    expect(Capybara.current_session.driver.request.session[Wizard::Steps::ImportDestination::STEP_ID]).to eq('XI')
   end
 
   it 'loses its session key when going back to the previous question' do
-    choose(option: 'ni')
+    choose(option: 'XI')
 
     click_on('Continue')
 
-    visit import_date_path(commodity_code: commodity_code, service_choice: service_choice)
+    click_on('Back')
+    click_on('Back')
 
     expect(Capybara.current_session.driver.request.session.key?(Wizard::Steps::ImportDestination::STEP_ID)).to be false
   end

--- a/spec/fixtures/country.json
+++ b/spec/fixtures/country.json
@@ -8,6 +8,15 @@
         "description": "Nicaragua",
         "geographical_area_id": "NI"
       }
+    },
+    {
+      "id": "XI",
+      "type": "geographical_area",
+      "attributes": {
+        "id": "XI",
+        "description": "United Kingdom (Northern Ireland)",
+        "geographical_area_id": "XI"
+      }
     }
   ]
 }

--- a/spec/models/duty_calculator_spec.rb
+++ b/spec/models/duty_calculator_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe DutyCalculator do
+  subject(:calculator) { described_class.new(user_session) }
+
+  let(:user_session) { UserSession.new(session) }
+
+  describe '#result' do
+    context 'when importing from NI to GB' do
+      let(:session) do
+        {
+          '2' => 'GB',
+          '3' => 'XI',
+        }
+      end
+
+      it 'returns 0' do
+        expect(calculator.result).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/models/user_session_spec.rb
+++ b/spec/models/user_session_spec.rb
@@ -94,4 +94,23 @@ RSpec.describe Wizard::Steps::UserSession do
       expect(session[Wizard::Steps::CountryOfOrigin::STEP_ID]).to eq(expected_country)
     end
   end
+
+  describe '#ni_to_gb_route?' do
+    context 'when import country is GB and origin country is NI' do
+      let(:session) do
+        {
+          '2' => 'GB',
+          '3' => 'XI',
+        }
+      end
+
+      it 'returns true' do
+        expect(user_session.ni_to_gb_route?).to be true
+      end
+    end
+
+    it 'returns false otherwise' do
+      expect(user_session.ni_to_gb_route?).to be false
+    end
+  end
 end

--- a/spec/models/wizard/steps/country_of_origin_spec.rb
+++ b/spec/models/wizard/steps/country_of_origin_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Wizard::Steps::CountryOfOrigin do
-  subject(:country) { described_class.new(user_session, attributes) }
+  subject(:step) { described_class.new(user_session, attributes) }
 
   let(:session) { {} }
   let(:user_session) { UserSession.new(session) }
@@ -15,13 +15,13 @@ RSpec.describe Wizard::Steps::CountryOfOrigin do
   describe '#validations' do
     context 'when geographical_area_id is blank' do
       it 'is not a valid object' do
-        expect(country.valid?).to be false
+        expect(step.valid?).to be false
       end
 
       it 'adds the correct validation error message' do
-        country.valid?
+        step.valid?
 
-        expect(country.errors.messages[:geographical_area_id]).to eq(['Enter a valid origin for this import'])
+        expect(step.errors.messages[:geographical_area_id]).to eq(['Enter a valid origin for this import'])
       end
     end
 
@@ -33,13 +33,13 @@ RSpec.describe Wizard::Steps::CountryOfOrigin do
       end
 
       it 'is a valid object' do
-        expect(country.valid?).to be true
+        expect(step.valid?).to be true
       end
 
       it 'has no validation errors' do
-        country.valid?
+        step.valid?
 
-        expect(country.errors.messages[:geographical_area_id]).to be_empty
+        expect(step.errors.messages[:geographical_area_id]).to be_empty
       end
     end
   end
@@ -52,9 +52,48 @@ RSpec.describe Wizard::Steps::CountryOfOrigin do
     end
 
     it 'saves the geographical_area_id to the session' do
-      country.save
+      step.save
 
       expect(user_session.geographical_area_id).to eq '2'
+    end
+  end
+
+  describe '#previous_step_path' do
+    include Rails.application.routes.url_helpers
+
+    let(:service_choice) { 'uk' }
+    let(:commodity_code) { '1233455' }
+
+    it 'returns import_destination_path' do
+      expect(
+        step.previous_step_path(service_choice: service_choice, commodity_code: commodity_code),
+      ).to eq(
+        import_destination_path(service_choice: service_choice, commodity_code: commodity_code),
+      )
+    end
+  end
+
+  describe '#next_step_path' do
+    include Rails.application.routes.url_helpers
+
+    let(:service_choice) { 'uk' }
+    let(:commodity_code) { '1233455' }
+
+    let(:session) do
+      {
+        '2' => 'GB',
+        '3' => 'XI',
+      }
+    end
+
+    context 'when on NI to GB route' do
+      it 'returns duty_path' do
+        expect(
+          step.next_step_path(service_choice: service_choice, commodity_code: commodity_code),
+        ).to eq(
+          duty_path(service_choice: service_choice, commodity_code: commodity_code),
+        )
+      end
     end
   end
 end

--- a/spec/models/wizard/steps/import_date_spec.rb
+++ b/spec/models/wizard/steps/import_date_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Wizard::Steps::ImportDate do
-  subject(:import_date) { described_class.new(user_session, attributes) }
+  subject(:step) { described_class.new(user_session, attributes) }
 
   let(:session) { {} }
   let(:user_session) { UserSession.new(session) }
@@ -24,13 +24,13 @@ RSpec.describe Wizard::Steps::ImportDate do
       end
 
       it 'is not a valid object' do
-        expect(import_date.valid?).to be false
+        expect(step.valid?).to be false
       end
 
       it 'adds the correct validation error message' do
-        import_date.valid?
+        step.valid?
 
-        expect(import_date.errors.messages[:import_date]).to eq(['Enter a valid future date'])
+        expect(step.errors.messages[:import_date]).to eq(['Enter a valid future date'])
       end
     end
 
@@ -44,13 +44,13 @@ RSpec.describe Wizard::Steps::ImportDate do
       end
 
       it 'is not a valid object' do
-        expect(import_date.valid?).to be false
+        expect(step.valid?).to be false
       end
 
       it 'adds the correct validation error message' do
-        import_date.valid?
+        step.valid?
 
-        expect(import_date.errors.messages[:import_date]).to eq(['Enter a valid future date'])
+        expect(step.errors.messages[:import_date]).to eq(['Enter a valid future date'])
       end
     end
 
@@ -64,13 +64,13 @@ RSpec.describe Wizard::Steps::ImportDate do
       end
 
       it 'is not a valid object' do
-        expect(import_date.valid?).to be false
+        expect(step.valid?).to be false
       end
 
       it 'adds the correct validation error message' do
-        import_date.valid?
+        step.valid?
 
-        expect(import_date.errors.messages[:import_date]).to eq(['Enter a valid future date'])
+        expect(step.errors.messages[:import_date]).to eq(['Enter a valid future date'])
       end
     end
 
@@ -84,13 +84,13 @@ RSpec.describe Wizard::Steps::ImportDate do
       end
 
       it 'is not a valid object' do
-        expect(import_date.valid?).to be false
+        expect(step.valid?).to be false
       end
 
       it 'adds the correct validation error message' do
-        import_date.valid?
+        step.valid?
 
-        expect(import_date.errors.messages[:import_date]).to eq(['Enter a valid future date'])
+        expect(step.errors.messages[:import_date]).to eq(['Enter a valid future date'])
       end
     end
 
@@ -104,25 +104,25 @@ RSpec.describe Wizard::Steps::ImportDate do
       end
 
       it 'is not a valid object' do
-        expect(import_date.valid?).to be false
+        expect(step.valid?).to be false
       end
 
       it 'adds the correct validation error message' do
-        import_date.valid?
+        step.valid?
 
-        expect(import_date.errors.messages[:import_date]).to eq(['Enter a valid future date'])
+        expect(step.errors.messages[:import_date]).to eq(['Enter a valid future date'])
       end
     end
 
     context 'when import date is valid and in future' do
       it 'is a valid object' do
-        expect(import_date.valid?).to be true
+        expect(step.valid?).to be true
       end
 
       it 'has no validation errors' do
-        import_date.valid?
+        step.valid?
 
-        expect(import_date.errors.messages[:import_date]).to be_empty
+        expect(step.errors.messages[:import_date]).to be_empty
       end
     end
   end
@@ -131,9 +131,24 @@ RSpec.describe Wizard::Steps::ImportDate do
     let(:expected_date) { Date.parse("#{1.year.from_now.year}-12-12") }
 
     it 'saves the import_date to the session' do
-      import_date.save
+      step.save
 
       expect(user_session.import_date).to eq(expected_date)
+    end
+  end
+
+  describe '#next_step_path' do
+    include Rails.application.routes.url_helpers
+
+    let(:service_choice) { 'uk' }
+    let(:commodity_code) { '1233455' }
+
+    it 'returns import_destination_path' do
+      expect(
+        step.next_step_path(service_choice: service_choice, commodity_code: commodity_code),
+      ).to eq(
+        import_destination_path(service_choice: service_choice, commodity_code: commodity_code),
+      )
     end
   end
 end

--- a/spec/models/wizard/steps/import_destination_spec.rb
+++ b/spec/models/wizard/steps/import_destination_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Wizard::Steps::ImportDestination do
-  subject(:country) { described_class.new(user_session, attributes) }
+  subject(:step) { described_class.new(user_session, attributes) }
 
   let(:session) { {} }
   let(:user_session) { UserSession.new(session) }
@@ -14,13 +14,13 @@ RSpec.describe Wizard::Steps::ImportDestination do
   describe '#validations' do
     context 'when import destination is blank' do
       it 'is not a valid object' do
-        expect(country.valid?).to be false
+        expect(step.valid?).to be false
       end
 
       it 'adds the correct validation error message' do
-        country.valid?
+        step.valid?
 
-        expect(country.errors.messages[:import_destination]).to eq(['Select a destination'])
+        expect(step.errors.messages[:import_destination]).to eq(['Select a destination'])
       end
     end
 
@@ -32,13 +32,13 @@ RSpec.describe Wizard::Steps::ImportDestination do
       end
 
       it 'is a valid object' do
-        expect(country.valid?).to be true
+        expect(step.valid?).to be true
       end
 
       it 'has no validation errors' do
-        country.valid?
+        step.valid?
 
-        expect(country.errors.messages[:import_destination]).to be_empty
+        expect(step.errors.messages[:import_destination]).to be_empty
       end
     end
   end
@@ -51,9 +51,39 @@ RSpec.describe Wizard::Steps::ImportDestination do
     end
 
     it 'saves the import_date to the session' do
-      country.save
+      step.save
 
       expect(user_session.import_destination).to eq('ni')
+    end
+  end
+
+  describe '#next_step_path' do
+    include Rails.application.routes.url_helpers
+
+    let(:service_choice) { 'uk' }
+    let(:commodity_code) { '1233455' }
+
+    it 'returns country_of_origin_path' do
+      expect(
+        step.next_step_path(service_choice: service_choice, commodity_code: commodity_code),
+      ).to eq(
+        country_of_origin_path(service_choice: service_choice, commodity_code: commodity_code),
+      )
+    end
+  end
+
+  describe '#previous_step_path' do
+    include Rails.application.routes.url_helpers
+
+    let(:service_choice) { 'uk' }
+    let(:commodity_code) { '1233455' }
+
+    it 'returns import_date_path' do
+      expect(
+        step.previous_step_path(service_choice: service_choice, commodity_code: commodity_code),
+      ).to eq(
+        import_date_path(service_choice: service_choice, commodity_code: commodity_code),
+      )
     end
   end
 end


### PR DESCRIPTION
### Jira link

HOTT-452

### What?

- use @step as ActiveModel object for any of the
wizard steps: import_date, import_destination, etc. It
makes more sense this way
- add next_step_path and previous_step_path methods on every
ActiveModel class, as we want to tackle the pathfinder logic
at each step in part, rather than have one big class with
all the rules
- add the first duty calculator version for NI to GB route
- add the duty page for NI to GB route
- use XI as area code for NI for consistency across the platform
